### PR TITLE
Use hashed string as cache directory name for viewing manga with loooooooong names

### DIFF
--- a/CosImg/ExHentai/ViewModel/ReadingViewModel.cs
+++ b/CosImg/ExHentai/ViewModel/ReadingViewModel.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.Security.Cryptography;
+using Windows.Security.Cryptography.Core;
 using TBase;
 using TBase.RT;
 
@@ -34,13 +36,21 @@ namespace CosImg.ExHentai.ViewModel
                 { 
                     ImageIndex = i,
                     ImagePage = PageList[i].ImagePage,
-                    SaveFolder = HeaderEn.Replace("\\","").Replace("/","").Replace(":","").Replace("*","").Replace("?","").Replace("\"","").Replace("<","").Replace(">","").Replace("|",""),
-                    //Image = await ParseHelper.GetImageAync(PageList[i].ImagePage, TBase.RT.SettingHelpers.GetSetting<string>("cookie")) 
+                    SaveFolder = HashedStringOf(HeaderEn) 
                 });
             }
             ImageList = temp;
             OnPropertyChanged("ImageList");
         }
+
+        private string HashedStringOf(string name)
+        {
+            Windows.Storage.Streams.IBuffer buff_utf8 = CryptographicBuffer.ConvertStringToBinary(name, Windows.Security.Cryptography.BinaryStringEncoding.Utf8);
+            HashAlgorithmProvider algprov = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithmNames.Sha1);
+            Windows.Storage.Streams.IBuffer buff_hash = algprov.HashData(buff_utf8);
+            return CryptographicBuffer.EncodeToHexString(buff_hash);
+        }
+
         public int SelectIndex { get; set; }
         public ICommand RefreshCommand
         {


### PR DESCRIPTION
When fetching manga with extraordinary long titles (such as `"(C87) [EINSATZ GRUPPE, MANITOU (Charlie Nishinaka, Nakajima Rei)] GunKan,Kansaiki no Himitsu Soushuuhen sono2 (Kantai Collection -KanColle-) [Chinese] [Genesis漢化]"`), the cache directory for that manga will have an extremely looooong path which will fail to create on the device. This commit uses hashed string of constant size to workaround this problem.
